### PR TITLE
Add new atvscript attributes to node_pyatv

### DIFF
--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -84,6 +84,13 @@ export default class NodePyATVDevice implements EventEmitter{
     }
 
     /**
+     * Get the MAC address of the Apple TV.
+     */
+    get mac(): string | undefined {
+        return this.options.mac;
+    }
+
+    /**
      * Get the model identifier of the device. Only set, if the
      * device was found using [[find()]]. Requires pyatv ≧ 0.10.3.
      *

--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -70,6 +70,13 @@ export default class NodePyATVDevice implements EventEmitter{
     }
 
     /**
+     * Get all IDs of the Apple TV.
+     */
+    get allIDs(): string[] | undefined {
+        return this.options.allIDs;
+    }
+
+    /**
      * Get the used protocol to connect to the Apple TV.
      */
     get protocol(): NodePyATVProtocol | undefined {

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -122,6 +122,7 @@ export default class NodePyATVInstance {
                 id: device.identifier,
                 allIDs: device.all_identifiers,
                 name: device.name,
+                mac: device.device_info?.mac,
                 model: device.device_info?.model,
                 modelName: device.device_info?.model_str,
                 os: device.device_info?.operating_system,

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -120,6 +120,7 @@ export default class NodePyATVInstance {
             this.device(Object.assign({}, options, {
                 host: device.address,
                 id: device.identifier,
+                allIDs: device.all_identifiers,
                 name: device.name,
                 model: device.device_info?.model,
                 modelName: device.device_info?.model_str,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,6 +157,7 @@ export interface NodePyATVDeviceOptions extends NodePyATVFindAndInstanceOptions 
     os?: string;
     version?: string;
     services?: NodePyATVService[];
+    allIDs?: string[];
 }
 
 export interface NodePyATVGetStateOptions {
@@ -175,6 +176,7 @@ export interface NodePyATVInternalScanDevice {
     name: string;
     address: string;
     identifier: string;
+    all_identifiers: string[];
     device_info?: {
         model: string;
         model_str: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,6 +152,7 @@ export interface NodePyATVFindAndInstanceOptions extends NodePyATVInstanceOption
 export interface NodePyATVDeviceOptions extends NodePyATVFindAndInstanceOptions {
     host: string;
     name: string;
+    mac?: string;
     model?: string;
     modelName?: string;
     os?: string;
@@ -178,6 +179,7 @@ export interface NodePyATVInternalScanDevice {
     identifier: string;
     all_identifiers: string[];
     device_info?: {
+        mac: string | null;
         model: string;
         model_str: string;
         operating_system: string;

--- a/test/device.ts
+++ b/test/device.ts
@@ -81,6 +81,18 @@ describe('NodePyATVDevice', function () {
         });
     });
 
+    describe('get mac()', function () {
+        it('should return the mac', function () {
+            const device = new NodePyATVDevice({
+                name: 'My Testdevice',
+                host: '192.168.178.2',
+                mac: 'AA:BB:CC:DD:EE:FF'
+            });
+
+            assert.strictEqual(device.mac, 'AA:BB:CC:DD:EE:FF');
+        });
+    });
+
     describe('get model()', function () {
         it('should return the model if set by scan', function () {
             const device = new NodePyATVDevice({

--- a/test/device.ts
+++ b/test/device.ts
@@ -48,6 +48,27 @@ describe('NodePyATVDevice', function () {
         });
     });
 
+    describe('get allIDs()', function () {
+        it('should return all the IDs', function () {
+            const device = new NodePyATVDevice({
+                name: 'My Testdevice',
+                host: '192.168.178.2',
+                id: '*****',
+                allIDs: [
+                    'some_id_1',
+                    'some_id_2',
+                    'some_id_3',
+                ]
+            });
+
+            assert.deepStrictEqual(device.allIDs, [
+                'some_id_1',
+                'some_id_2',
+                'some_id_3',
+            ]);
+        });
+    });
+
     describe('get protocol()', function () {
         it('should return the protocol', function () {
             const device = new NodePyATVDevice({


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Feature
- **What is the current behavior?** (You can also link to an open issue here)
    - the attributes `all_identififiers` and `mac` that are part of the `atvscript scan` response, are not part of this library yet
- **What is the new behavior (if this is a feature change)?**
    - add the attributes to the library
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - breaks compatability with `pyatv<=0.14.4`
- **Other information**:
    - relates to https://github.com/postlund/pyatv/pull/2282


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
    - **isn't the documentation generated from the comments fo the methods?**
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
