### PR TITLE
fix(core): incorrect state tracking

### DIFF
--- a/src/lib/device-events.ts
+++ b/src/lib/device-events.ts
@@ -91,7 +91,7 @@ export default class NodePyATVDeviceEvents extends EventEmitter {
 
     private applyPushUpdate(update: NodePyATVInternalState, reqId: string): void {
         try {
-            const newState = parseState(update, reqId, this.options);
+            const newState = parseState(update, this.state, reqId, this.options);
             this.applyStateAndEmitEvents(newState);
         }
         catch(error) {

--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -34,7 +34,7 @@ export default class NodePyATVDevice implements EventEmitter{
 
     constructor(options: NodePyATVDeviceOptions) {
         this.options = Object.assign({}, options);
-        this.state = parseState({}, '', {});
+        this.state = parseState({}, undefined, '', {});
         this.events = new NodePyATVDeviceEvents(this.state, this, this.options);
 
         // @todo basic validation
@@ -232,7 +232,7 @@ export default class NodePyATVDevice implements EventEmitter{
             const parameters = getParamters(this.options);
 
             const result = await request(id, NodePyATVExecutableType.atvscript, [...parameters, 'playing'], this.options);
-            const newState = parseState(result, id, this.options);
+            const newState = parseState(result, this.state, id, this.options);
 
             this.applyState(newState);
             return newState;
@@ -248,7 +248,7 @@ export default class NodePyATVDevice implements EventEmitter{
      * @category State
      */
     clearState(): void {
-        this.applyState(parseState({}, '', {}));
+        this.applyState(parseState({}, undefined, '', {}));
     }
 
     private applyState(newState: NodePyATVState): void {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -234,7 +234,7 @@ function parseStateStringAttr(
     d(`No ${outputAttr} value found in input (${JSON.stringify(input)})`);
 }
 
-export function parseState(input: NodePyATVInternalState, id: string, options: NodePyATVInstanceOptions): NodePyATVState {
+export function parseState(input: NodePyATVInternalState, currentState: NodePyATVState | undefined, id: string, options: NodePyATVInstanceOptions): NodePyATVState {
     const d = (msg: string) => debug(id, msg, options);
     const result: NodePyATVState = {
         dateTime: null,
@@ -253,7 +253,8 @@ export function parseState(input: NodePyATVInternalState, id: string, options: N
         appId: null,
         powerState: null,
         volume: null,
-        focusState: null
+        focusState: null,
+        ...currentState
     };
     if (!input || typeof input !== 'object') {
         return result;

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -123,7 +123,7 @@ describe('Tools', function () {
     describe('parseState()', function () {
         it('should work with empty data', function () {
             const input = {};
-            const result = parseState(input, '', {});
+            const result = parseState(input, undefined, '', {});
             assert.deepStrictEqual(result, {
                 dateTime: null,
                 hash: null,
@@ -146,7 +146,7 @@ describe('Tools', function () {
         });
         it('should work without data', function () {
             // @ts-ignore
-            const result = parseState(null, '', {});
+            const result = parseState(null, undefined, '', {});
             assert.deepStrictEqual(result, {
                 dateTime: null,
                 hash: null,
@@ -188,7 +188,7 @@ describe('Tools', function () {
                 focusState: null,
                 volume: null
             };
-            const result = parseState(input, '', {});
+            const result = parseState(input, undefined, '', {});
             assert.deepStrictEqual(result, {
                 dateTime: new Date('2020-11-07T22:38:43.608030+01:00'),
                 hash: '100e0ab6-6ff5-4199-9c04-a7107ff78712',
@@ -217,12 +217,12 @@ describe('Tools', function () {
                 stacktrace: 'Traceback (most recent call last):\n  File \"/Users/free/Library/Python/3.8/lib/python/site-packages/pyatv/scripts/atvscript.py\", line 302, in appstart\n    print(args.output(await _handle_command(args, abort_sem, loop)), flush=True)\n  File \"/Users/free/Library/Python/3.8/lib/python/site-packages/pyatv/scripts/atvscript.py\", line 196, in _handle_command\n    atv = await connect(config, loop, protocol=Protocol.MRP)\n  File \"/Users/free/Library/Python/3.8/lib/python/site-packages/pyatv/__init__.py\", line 96, in connect\n    for setup_data in proto_methods.setup(\n  File \"/Users/free/Library/Python/3.8/lib/python/site-packages/pyatv/protocols/airplay/__init__.py\", line 192, in setup\n    stream = AirPlayStream(config, service)\n  File \"/Users/free/Library/Python/3.8/lib/python/site-packages/pyatv/protocols/airplay/__init__.py\", line 79, in __init__\n    self._credentials: HapCredentials = parse_credentials(self.service.credentials)\n  File \"/Users/free/Library/Python/3.8/lib/python/site-packages/pyatv/auth/hap_pairing.py\", line 139, in parse_credentials\n    raise exceptions.InvalidCredentialsError(\"invalid credentials: \" + detail_string)\npyatv.exceptions.InvalidCredentialsError: invalid credentials: 321\n'
             };
             assert.throws(() => {
-                parseState(input, '', {});
+                parseState(input, undefined, '', {});
             }, /Got pyatv Error: invalid credentials: 321/);
         });
         it('should ignore date if it\'s an invalid date', function () {
             const input = { datetime: 'today' };
-            const result = parseState(input, '', {});
+            const result = parseState(input, undefined, '', {});
             assert.deepStrictEqual(result, {
                 dateTime: null,
                 hash: null,
@@ -264,7 +264,7 @@ describe('Tools', function () {
                 focusState: null,
                 volume: null
             };
-            const result = parseState(input, '', {});
+            const result = parseState(input, undefined, '', {});
             assert.deepStrictEqual(result, {
                 dateTime: null,
                 hash: null,
@@ -292,7 +292,7 @@ describe('Tools', function () {
                 shuffle: 'everything',
                 repeat: 'nothing'
             };
-            const result = parseState(input, '', {});
+            const result = parseState(input, undefined, '', {});
             assert.deepStrictEqual(result, {
                 dateTime: null,
                 hash: null,
@@ -311,6 +311,52 @@ describe('Tools', function () {
                 powerState: null,
                 focusState: null,
                 volume: null
+            });
+        });
+        it('should consider the current state', function () {
+            const input = {
+                result: 'success',
+                datetime: '2020-11-07T22:38:44.608030+01:00',
+                volume: 42
+            };
+            const currentState = {
+                dateTime: new Date('2020-11-07T22:38:43.608030+01:00'),
+                hash: '100e0ab6-6ff5-4199-9c04-a7107ff78712',
+                mediaType: NodePyATVMediaType.video,
+                deviceState: NodePyATVDeviceState.playing,
+                title: 'Solo: A Star Wars Story',
+                artist: null,
+                album: null,
+                genre: null,
+                totalTime: 8097,
+                position: 27,
+                shuffle: NodePyATVShuffleState.off,
+                repeat: NodePyATVRepeatState.off,
+                app: 'Disney+',
+                appId: 'com.disney.disneyplus',
+                powerState: null,
+                focusState: null,
+                volume: null
+            };
+            const result = parseState(input, currentState, '', {});
+            assert.deepStrictEqual(result, {
+                dateTime: new Date('2020-11-07T22:38:44.608030+01:00'),
+                hash: '100e0ab6-6ff5-4199-9c04-a7107ff78712',
+                mediaType: NodePyATVMediaType.video,
+                deviceState: NodePyATVDeviceState.playing,
+                title: 'Solo: A Star Wars Story',
+                artist: null,
+                album: null,
+                genre: null,
+                totalTime: 8097,
+                position: 27,
+                shuffle: NodePyATVShuffleState.off,
+                repeat: NodePyATVRepeatState.off,
+                app: 'Disney+',
+                appId: 'com.disney.disneyplus',
+                powerState: null,
+                focusState: null,
+                volume: 42
             });
         });
     });


### PR DESCRIPTION
Hi,

I think I found a major bug in this otherwise awesome library.

The current state of a device was not taken into consideration when generating the updated state after receiving an update from `atvscript`. This way, attributes that are not reported in that specific result of `atvscript`, default to `null`, which is unwanted since in reality they are still unchanged and not `null`.

E.g. when changing the volume, all attributes beside the volume are set to `null`, since the volume attribute is the only one reported by atvscript when changing the volume:

```json
{
    "result": "success",
    "datetime": "2023-12-28T22:19:30.570684+01:00",
    "volume": 50.0
}
```

All attributes beside `volume` will default to `null` resulting in a wrong state and unnecessary event listener triggers:

https://github.com/sebbo2002/node-pyatv/blob/65cbc62b8e65e85c6f82a0474d4dfb91c6663eeb/src/lib/tools.ts#L239C4-L239C4

### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - …
- **What is the current behavior?** (You can also link to an open issue here)
    - …
- **What is the new behavior (if this is a feature change)?**
    - …
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - …
- **Other information**:
    - …


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
