### PR TITLE
fix(core): fix insufficient comparison in applyStateAndEmitEvents

### DIFF
--- a/src/lib/deepEqual.ts
+++ b/src/lib/deepEqual.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+'use strict';
+
+export default function deepEqual(a: any, b: any): boolean {
+
+    // primitive
+    const aPrimitive: boolean = isPrimitive(a);
+    const bPrimitive: boolean = isPrimitive(b);
+    if (aPrimitive && bPrimitive) {
+        return isPrimitiveEqual(a, b);
+    }
+    if (aPrimitive || bPrimitive) {
+        return false;
+    }
+
+    // array
+    const aArray: boolean = Array.isArray(a);
+    const bArray: boolean = Array.isArray(b);
+    if (aArray && bArray) {
+        return isArrayEqual(a, b);
+    }
+    if (aArray || bArray) {
+        // if only a or b is an array, they can't be the same
+        return false;
+    }
+
+    // object
+    const aObject: boolean = typeof a === 'object';
+    const bObject: boolean = typeof b === 'object';
+    if (aObject && bObject) {
+        return isObjectEqual(a, b);
+    }
+    if (aObject || bObject) {
+        // if only a or b is an object, they can't be the same
+        return false;
+    }
+
+    return false;
+}
+
+export function isPrimitive(e: any): boolean {
+    return e !== Object(e);
+};
+
+export function isPrimitiveEqual(a: any, b: any): boolean {
+    return a === b;
+}
+
+export function isArrayEqual(a: any[], b: any[]): boolean {
+    if (a.length !== b.length) {
+        // if there are different number of elements, the arrays can't be the same
+        return false;
+    }
+
+    // check if every element of a has a counter part in b
+    for (let i: number = 0; i < a.length; i++) {
+        // look at a[i]
+        for (let j: number = 0; j < b.length; j++) {
+            // now search for a matching element in b
+            if (deepEqual(a[i], b[j]) === true) {
+                // there is our matching element
+                // delete element so it is not matched twice
+                b.splice(j, 1);
+                // go on with a[i + 1]
+                break;
+            }
+            if (j === b.length - 1) {
+                // if the for loop got so far, there was no match for a[i] in b
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+export function isObjectEqual(a: object, b: object): boolean {
+    // check if the same keys are present
+    const aKeys: string[] = Object.keys(a);
+    const bKeys: string[] = Object.keys(b);
+    if (aKeys.length !== bKeys.length) {
+        // if there are different number of keys, the objects can't be the same
+        return false;
+    }
+    for (const k of aKeys) {
+        if (bKeys.includes(k) === false) {
+            return false;
+        }
+    }
+
+    // check if content is the same
+    for (const k of aKeys) {
+        if (deepEqual(a[k], b[k]) === false) {
+            return false;
+        }
+    }
+        
+    // both object have the same content
+    return true;
+}

--- a/src/lib/device-events.ts
+++ b/src/lib/device-events.ts
@@ -14,6 +14,7 @@ import {EventEmitter} from 'events';
 import {NodePyATVDevice, NodePyATVDeviceEvent} from '../lib/index.js';
 import {addRequestId, debug, execute, getParamters, parseState, removeRequestId} from './tools.js';
 import {FakeChildProcess} from './fake-spawn.js';
+import deepEqual from './deepEqual.js';
 
 /**
  * @internal
@@ -68,7 +69,7 @@ export default class NodePyATVDeviceEvents extends EventEmitter {
             // @ts-ignore
             const newValue = newState[key];
 
-            if(oldValue === undefined || newValue === undefined || oldValue === newValue) {
+            if(oldValue === undefined || newValue === undefined || deepEqual(oldValue, newValue)) {
                 return;
             }
 

--- a/test/deepEqual.ts
+++ b/test/deepEqual.ts
@@ -1,0 +1,271 @@
+'use strict';
+
+import assert from 'assert';
+import deepEqual, { isArrayEqual, isObjectEqual, isPrimitive, isPrimitiveEqual } from '../src/lib/deepEqual.js';
+
+
+describe('deep equal', function () {
+    describe('isPrimitive()', function () {
+        it('should detect primitives', function () {
+            assert.strictEqual(true, isPrimitive(true));
+            assert.strictEqual(true, isPrimitive(false));
+            assert.strictEqual(true, isPrimitive(0));
+            assert.strictEqual(true, isPrimitive(42));
+            assert.strictEqual(true, isPrimitive(1.23));
+            assert.strictEqual(true, isPrimitive(undefined));
+            assert.strictEqual(true, isPrimitive(null));
+            assert.strictEqual(true, isPrimitive('string'));
+        });
+        it('should detect non-primitives', function () {
+            assert.strictEqual(false, isPrimitive([]));
+            assert.strictEqual(false, isPrimitive([0, 1, 2]));
+            assert.strictEqual(false, isPrimitive({}));
+            assert.strictEqual(false, isPrimitive({test: 42}));
+            assert.strictEqual(false, isPrimitive({test: [0, 1, 2]}));
+            assert.strictEqual(false, isPrimitive([{test: 42}]));
+        });
+    });
+
+    describe('isPrimitiveEqual()', function () {
+        it('should compare primitives correct', function () {
+            assert.strictEqual(true, isPrimitiveEqual(true, true));
+            assert.strictEqual(true, isPrimitiveEqual(false, false));
+            assert.strictEqual(false, isPrimitiveEqual(false, true));
+            assert.strictEqual(false, isPrimitiveEqual(true, false));
+            assert.strictEqual(true, isPrimitiveEqual('string', 'string'));
+            assert.strictEqual(false, isPrimitiveEqual('string1', 'string2'));
+            assert.strictEqual(false, isPrimitiveEqual(true, 'true'));
+            assert.strictEqual(false, isPrimitiveEqual(false, 'false'));
+            assert.strictEqual(false, isPrimitiveEqual(42, '42'));
+            assert.strictEqual(true, isPrimitiveEqual(42, 42));
+            assert.strictEqual(false, isPrimitiveEqual(42, 1));
+            assert.strictEqual(false, isPrimitiveEqual(true, 1));
+            assert.strictEqual(false, isPrimitiveEqual(false, 0));
+            assert.strictEqual(false, isPrimitiveEqual(undefined, 'undefined'));
+            assert.strictEqual(true, isPrimitiveEqual(undefined, undefined));
+            assert.strictEqual(false, isPrimitiveEqual(null, 'null'));
+            assert.strictEqual(true, isPrimitiveEqual(null, null));
+        });
+    });
+
+    describe('isArrayEqual()', function () {
+        it('should compare arrays correct', function () {
+            assert.strictEqual(true, isArrayEqual([], []));
+
+            assert.strictEqual(false, isArrayEqual([], [1]));
+            assert.strictEqual(false, isArrayEqual([1], []));
+
+            assert.strictEqual(false, isArrayEqual([1], [1, 2]));
+            assert.strictEqual(false, isArrayEqual([1, 2], [1]));
+
+            assert.strictEqual(true, isArrayEqual([1], [1]));
+            assert.strictEqual(true, isArrayEqual([1, 2], [1, 2]));
+            assert.strictEqual(true, isArrayEqual([1, 2], [2, 1]));
+            assert.strictEqual(true, isArrayEqual([1, 2, 3, 4], [4, 2, 1, 3]));
+
+            assert.strictEqual(false, isArrayEqual([1], [0]));
+            assert.strictEqual(false, isArrayEqual([1, 2], [0, 2]));
+            assert.strictEqual(false, isArrayEqual([1, 1, 2], [2, 1, 2]));
+            assert.strictEqual(false, isArrayEqual([1, 2, 3, 4], [4, 2, 1, 42]));
+        });
+    });
+
+    describe('isObjectEqual()', function () {
+        it('should compare objects correct', function () {
+            assert.strictEqual(true, isObjectEqual({}, {}));
+
+            assert.strictEqual(true, isObjectEqual({test: 42}, {test: 42}));
+            assert.strictEqual(true, isObjectEqual({test: 42, test2: 10}, {test: 42, test2: 10}));
+            assert.strictEqual(true, isObjectEqual({test: 42, test2: 10}, {test: 42, test2: 10}));
+
+            assert.strictEqual(false, isObjectEqual({test: 42}, {}));
+            assert.strictEqual(false, isObjectEqual({test: 42, test2: 10}, {test2: 11}));
+            assert.strictEqual(false, isObjectEqual({test: 42, test2: 10}, {test: 42, test2: 10, test3: -5}));
+
+            assert.strictEqual(false, isObjectEqual({test: 42}, {test: 43}));
+            assert.strictEqual(false, isObjectEqual({test: 42, test2: 10}, {test: 42, test2: 11}));
+            assert.strictEqual(false, isObjectEqual({test: 42, test2: 10}, {test: 42, test3: 10}));
+        });
+    });
+
+    describe('deepEqual()', function () {
+        it('should compare primitives correct', function () {
+            assert.strictEqual(true, deepEqual(true, true));
+            assert.strictEqual(true, deepEqual(false, false));
+            assert.strictEqual(false, deepEqual(false, true));
+            assert.strictEqual(false, deepEqual(true, false));
+            assert.strictEqual(true, deepEqual('string', 'string'));
+            assert.strictEqual(false, deepEqual('string1', 'string2'));
+            assert.strictEqual(false, deepEqual(true, 'true'));
+            assert.strictEqual(false, deepEqual(false, 'false'));
+            assert.strictEqual(false, deepEqual(42, '42'));
+            assert.strictEqual(true, deepEqual(42, 42));
+            assert.strictEqual(false, deepEqual(42, 1));
+            assert.strictEqual(false, deepEqual(true, 1));
+            assert.strictEqual(false, deepEqual(false, 0));
+            assert.strictEqual(false, deepEqual(undefined, 'undefined'));
+            assert.strictEqual(true, deepEqual(undefined, undefined));
+            assert.strictEqual(false, deepEqual(null, 'null'));
+            assert.strictEqual(true, deepEqual(null, null));
+        });
+
+        it('should compare arrays correct', function () {
+            assert.strictEqual(true, deepEqual([], []));
+
+            assert.strictEqual(false, deepEqual([], [1]));
+            assert.strictEqual(false, deepEqual([1], []));
+
+            assert.strictEqual(false, deepEqual([1], [1, 2]));
+            assert.strictEqual(false, deepEqual([1, 2], [1]));
+
+            assert.strictEqual(true, deepEqual([1], [1]));
+            assert.strictEqual(true, deepEqual([1, 2], [1, 2]));
+            assert.strictEqual(true, deepEqual([1, 2], [2, 1]));
+            assert.strictEqual(true, deepEqual([1, 2, 3, 4], [4, 2, 1, 3]));
+
+            assert.strictEqual(false, deepEqual([1], [0]));
+            assert.strictEqual(false, deepEqual([1, 2], [0, 2]));
+            assert.strictEqual(false, deepEqual([1, 1, 2], [2, 1, 2]));
+            assert.strictEqual(false, deepEqual([1, 2, 3, 4], [4, 2, 1, 42]));
+        });
+
+        it('should compare objects correct', function () {
+            assert.strictEqual(true, deepEqual({}, {}));
+
+            assert.strictEqual(true, deepEqual({test: 42}, {test: 42}));
+            assert.strictEqual(true, deepEqual({test: 42, test2: 10}, {test: 42, test2: 10}));
+            assert.strictEqual(true, deepEqual({test: 42, test2: 10}, {test: 42, test2: 10}));
+
+            assert.strictEqual(false, deepEqual({test: 42}, {}));
+            assert.strictEqual(false, deepEqual({test: 42, test2: 10}, {test2: 11}));
+            assert.strictEqual(false, deepEqual({test: 42, test2: 10}, {test: 42, test2: 10, test3: -5}));
+
+            assert.strictEqual(false, deepEqual({test: 42}, {test: 43}));
+            assert.strictEqual(false, deepEqual({test: 42, test2: 10}, {test: 42, test2: 11}));
+            assert.strictEqual(false, deepEqual({test: 42, test2: 10}, {test: 42, test3: 10}));
+        });
+
+        it('should compare complex object correct', function () {
+            assert.strictEqual(true, deepEqual(
+                {
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        model: 'EQE',
+                        hp: 500
+                    },
+                    car2: {
+                        manufacture: 'Audi',
+                        model: 'A6',
+                        hp: 230
+                    }
+                },
+                {
+                    car2: {
+                        model: 'A6',
+                        hp: 230,
+                        manufacture: 'Audi'
+                    },
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        hp: 500,
+                        model: 'EQE'
+                    },
+                }
+            ));
+
+            assert.strictEqual(true, deepEqual(
+                {
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        seats: [
+                            { id: 0, heating: true },
+                            { id: 1, heating: true },
+                            { id: 4, heating: false },
+                            { id: 2, heating: true },
+                            { id: 3, heating: true }
+                        ],
+                        model: 'EQE',
+                        hp: 500
+                    },
+                    car2: {
+                        manufacture: 'Audi',
+                        model: 'A6',
+                        hp: 230
+                    }
+                },
+                {
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        model: 'EQE',
+                        hp: 500,
+                        seats: [
+                            { id: 0, heating: true },
+                            { id: 1, heating: true },
+                            { id: 2, heating: true },
+                            { id: 3, heating: true },
+                            { id: 4, heating: false }
+                        ]
+                    },
+                    car2: {
+                        manufacture: 'Audi',
+                        model: 'A6',
+                        hp: 230
+                    }
+                }
+            ));
+
+            assert.strictEqual(false, deepEqual(
+                {
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        model: 'EQE',
+                        hp: 500
+                    },
+                    car2: {
+                        manufacture: 'Audi',
+                        model: 'A6'
+                    }
+                },
+                {
+                    car2: {
+                        model: 'A6',
+                        hp: 230,
+                        manufacture: 'Audi'
+                    },
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        hp: 500,
+                        model: 'EQE'
+                    },
+                }
+            ));
+
+            assert.strictEqual(false, deepEqual(
+                {
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        model: 'EQE',
+                        hp: 499
+                    },
+                    car2: {
+                        manufacture: 'Audi',
+                        model: 'A6',
+                        hp: 230
+                    }
+                },
+                {
+                    car2: {
+                        model: 'A6',
+                        hp: 230,
+                        manufacture: 'Audi'
+                    },
+                    car1: {
+                        manufacture: 'Mercedes-Benz',
+                        hp: 500,
+                        model: 'EQE'
+                    },
+                }
+            ));
+        });
+    });
+});


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - fix, since the introduction of `outputDevices` to this library, it is required to compare state changes of the attributes with a deep comparison instead of a flat one, since `[{"test": 1}] == [{"test": 1}]` is `false` in JavaScript. Therefore a deep comparison is required in order to fix #295 
- **What is the current behavior?** (You can also link to an open issue here)
    - …
- **What is the new behavior (if this is a feature change)?**
    - …
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - …
- **Other information**:
    - …


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
