### PR TITLE
fix(core): fix unintentional event trigger

### DIFF
--- a/src/lib/device-events.ts
+++ b/src/lib/device-events.ts
@@ -58,7 +58,7 @@ export default class NodePyATVDeviceEvents extends EventEmitter {
 
         // Volume events don't hold the complete state…
         // see https://github.com/sebbo2002/node-pyatv/pull/291
-        if('volume' in newState && newState.volume) {
+        if('volume' in newState && newState.volume !== null) {
             keys = ['volume'];
         }
 


### PR DESCRIPTION
Currently, if `atvscript` is reporting `{"result": "success", "datetime": "xxx", "volume": 0.0}`, all events but volume are triggered, since `volume` is not catched as a special case. The reason is that the condition `newState.volume` is false for `0.0`. Therefore, the condition should be `newState.volume !== null`.

https://github.com/sebbo2002/node-pyatv/blob/478f2ddb97af0dc2e4ffa417aecacbbf76d22ab3/src/lib/device-events.ts#L59-L63

```logs
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] Wohnzimmer (A8:51:AB:02:4D:6F): Rocket Remote: set_output_devices=82091D04-8D8E-4CF8-8FAA-4B7FC9979EB9
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] stdout: {"result": "success", "datetime": "2024-01-16T00:55:45.836461+01:00", "volume": 0.0}
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] > {"result": "success", "datetime": "2024-01-16T00:55:45.836461+01:00", "volume": 0.0}
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No hash value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No mediaType value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No deviceState value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No title value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No artist value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No album value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No genre value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No totalTime value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No position value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No shuffle value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No repeat value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No app value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No appId value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No powerState value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] CustomPyATVInstance: [node-pyatv][30] No focusState value found in input ({"result":"success","datetime":"2024-01-16T00:55:45.836461+01:00","volume":0})
[1/16/2024, 12:55:45 AM] [Apple TV Enhanced] Wohnzimmer (A8:51:AB:02:4D:6F): event mediaType: null
```

### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
    - e.g. the event `update:mediaType` is triggered although it shouldn't
- **What is the new behavior (if this is a feature change)?**
    - event don't get triggered unintentionally
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - …
- **Other information**:
    - …


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
