### PR TITLE
fix: Support for `seriesName` fixed

### DIFF
--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -468,8 +468,8 @@ export default class NodePyATVDevice implements EventEmitter{
      * @param options
      * @category State
      */
-    async getSeasonName(options: NodePyATVGetStateOptions = {}): Promise<string | null> {
-        return this.getState(options).then(state => state.seasonName);
+    async getSeriesName(options: NodePyATVGetStateOptions = {}): Promise<string | null> {
+        return this.getState(options).then(state => state.seriesName);
     }
 
     /**

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -250,8 +250,8 @@ export function getParameters(options: NodePyATVFindAndInstanceOptions = {}): st
 function parseStateStringAttr(
     input: NodePyATVInternalState,
     output: NodePyATVState,
-    inputAttr: ('hash' | 'title' | 'album' | 'artist' | 'genre' | 'app' | 'app_id' | 'content_identifier' | 'season_name'),
-    outputAttr: ('hash' | 'title' | 'album' | 'artist' | 'genre' | 'app' | 'appId' | 'contentIdentifier' | 'seasonName'),
+    inputAttr: ('hash' | 'title' | 'album' | 'artist' | 'genre' | 'app' | 'app_id' | 'content_identifier' | 'series_name'),
+    outputAttr: ('hash' | 'title' | 'album' | 'artist' | 'genre' | 'app' | 'appId' | 'contentIdentifier' | 'seriesName'),
     d: (msg: string) => void
 ): void {
     if (typeof input[inputAttr] === 'string') {
@@ -301,7 +301,7 @@ export function parseState(input: NodePyATVInternalState, id: string, options: N
         contentIdentifier: null,
         episodeNumber: null,
         seasonNumber: null,
-        seasonName: null
+        seriesName: null
     };
     if (!input || typeof input !== 'object') {
         return result;
@@ -449,8 +449,8 @@ export function parseState(input: NodePyATVInternalState, id: string, options: N
     // seasonNumber
     parseStateNumberAttr(input, result, 'season_number', 'seasonNumber', d);
 
-    // seasonName
-    parseStateStringAttr(input, result, 'season_name', 'seasonName', d);
+    // seriesName
+    parseStateStringAttr(input, result, 'series_name', 'seriesName', d);
 
     return result;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -235,7 +235,7 @@ export interface NodePyATVInternalState {
     content_identifier?: string | null;
     episode_number?: number | null;
     season_number?: number | null;
-    season_name?: string | null;
+    series_name?: string | null;
 }
 
 export interface NodePyATVState {
@@ -260,7 +260,7 @@ export interface NodePyATVState {
     contentIdentifier: string | null;
     episodeNumber: number | null;
     seasonNumber: number | null;
-    seasonName: string | null;
+    seriesName: string | null;
 }
 
 export interface NodePyATVApp {

--- a/test/device.ts
+++ b/test/device.ts
@@ -397,7 +397,7 @@ describe('NodePyATVDevice', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
         it('should reject with error if pyatv fails', async function () {
@@ -898,7 +898,7 @@ describe('NodePyATVDevice', function () {
         });
     });
 
-    describe('getSeasonName()', function () {
+    describe('getSeriesName()', function () {
         it('should work', async function () {
             const device = new NodePyATVDevice({
                 name: 'My Testdevice',
@@ -906,12 +906,12 @@ describe('NodePyATVDevice', function () {
                 spawn: createFakeSpawn(cp => {
                     cp.end({
                         result: 'success',
-                        season_name: 'The Testing Disaster'
+                        series_name: 'The Testing Disaster'
                     });
                 })
             });
 
-            const result = await device.getSeasonName();
+            const result = await device.getSeriesName();
             assert.strictEqual(result, 'The Testing Disaster');
         });
     });

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -146,7 +146,7 @@ describe('Tools', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
         it('should work without data', function () {
@@ -174,7 +174,7 @@ describe('Tools', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
         it('should work with example data', function () {
@@ -201,7 +201,7 @@ describe('Tools', function () {
                 content_identifier: null,
                 episode_number: null,
                 season_number: null,
-                season_name: null
+                series_name: null
             };
             const result = parseState(input, '', {});
             assert.deepStrictEqual(result, {
@@ -226,7 +226,7 @@ describe('Tools', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
         it('should throw an error for pyatv exceptions', function () {
@@ -265,7 +265,7 @@ describe('Tools', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
         it('should ignore data if unsupported type', function () {
@@ -292,7 +292,7 @@ describe('Tools', function () {
                 content_identifier: null,
                 episode_number: null,
                 season_number: null,
-                season_name: null
+                series_name: null
             };
             const result = parseState(input, '', {});
             assert.deepStrictEqual(result, {
@@ -317,7 +317,7 @@ describe('Tools', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
         it('should ignore enums with unsupported valid', function () {
@@ -350,7 +350,7 @@ describe('Tools', function () {
                 contentIdentifier: null,
                 episodeNumber: null,
                 seasonNumber: null,
-                seasonName: null
+                seriesName: null
             });
         });
     });


### PR DESCRIPTION
There was support added for `seasonName` although it should be `seriesName`.

### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - bug fix
- **What is the current behavior?** (You can also link to an open issue here)
    - a non-existing pyatv attribute is exposed
- **What is the new behavior (if this is a feature change)?**
    - the correct one is exposed
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - no, since the bug that is being fixed is not released yet
- **Other information**:
    - …


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
