### PR TITLE
fix: correct NodePyATVDevice.listenerCount method signature

### DIFF
--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -651,7 +651,7 @@ export default class NodePyATVDevice implements EventEmitter {
      * @param event
      * @category Event
      */
-    listenerCount(event: string | symbol): number {
+    listenerCount(event?: string | symbol): number {
         return this.events.listenerCount(event);
     }
 


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - bug fix
- **What is the current behavior?** (You can also link to an open issue here)
    - To get the total number of counters on a `NodePyATVDevice`, I have to call `this.device.listenerCount(undefined as unknown as string)`
- **What is the new behavior (if this is a feature change)?**
    - `this.device.listenerCount()`
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - No
- **Other information**:
    - …


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
